### PR TITLE
Add basic Discord bot that broadcasts messages to local server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # 0000Discordin
+
+## Overview
+This project provides a simple Discord bot that forwards all messages to a local HTTP endpoint and watches for the `!req` command. When `!req` is detected, the bot responds with "Request received." and still forwards the message.
+
+## Setup
+1. Install [Python 3](https://www.python.org/downloads/) on Windows.
+2. Edit `config.ini` and replace `PLACEHOLDER_TOKEN` with your Discord bot token.
+3. Run `install.bat` to create a virtual environment and install dependencies.
+
+## Running the Bot
+1. Double-click `launch.bat` or run it from Command Prompt.
+2. The bot reads all messages and POSTs them to `http://localhost:1010` as JSON:
+   ```json
+   {
+       "user": "username#1234",
+       "content": "message text",
+       "is_request": false
+   }
+   ```
+
+## Notes
+- Ensure you have a service listening on port 1010 to receive the messages.
+- Enable the *Message Content Intent* for your bot in the Discord Developer Portal.
+
+

--- a/agents/NOTES.md
+++ b/agents/NOTES.md
@@ -1,0 +1,18 @@
+# Development Notes
+
+## Completed
+- Created Discord bot that broadcasts all messages to `http://localhost:1010` and replies to `!req`.
+- Added configuration file `config.ini` holding all settings.
+- Provided Windows batch scripts for installation and launching.
+- Wrote setup instructions in `README.md`.
+
+## Partially Done
+- No receiver service at `localhost:1010` implemented.
+- No advanced command handling beyond `!req`.
+
+## Next Steps
+- Implement a local server to capture broadcasts.
+- Extend bot with additional commands and logging.
+
+## Completion
+- Estimated completion: 60%

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,36 @@
+import discord
+import aiohttp
+import configparser
+
+config = configparser.ConfigParser()
+config.read('config.ini')
+
+TOKEN = config['bot']['token']
+BROADCAST_URL = config['bot']['broadcast_url']
+
+intents = discord.Intents.default()
+intents.message_content = True
+client = discord.Client(intents=intents)
+
+async def broadcast_message(message, is_request=False):
+    data = {
+        'user': str(message.author),
+        'content': message.content,
+        'is_request': is_request,
+    }
+    try:
+        async with aiohttp.ClientSession() as session:
+            await session.post(BROADCAST_URL, json=data)
+    except Exception as e:
+        print(f'Broadcast failed: {e}')
+
+@client.event
+async def on_message(message):
+    if message.author == client.user:
+        return
+    is_req = message.content.startswith('!req')
+    await broadcast_message(message, is_request=is_req)
+    if is_req:
+        await message.channel.send('Request received.')
+
+client.run(TOKEN)

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,11 @@
+[bot]
+# Discord bot token
+# Replace PLACEHOLDER_TOKEN with your actual bot token
+# This is a placeholder
+# There is no default token
+# For security, keep this file private
+# Example: token = ABCDEFG
+# For broadcasting HTTP endpoint
+# Example: broadcast_url = http://localhost:1010/
+token = PLACEHOLDER_TOKEN
+broadcast_url = http://localhost:1010/

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,4 @@
+@echo off
+python -m venv venv
+venv\Scripts\python -m pip install --upgrade pip
+venv\Scripts\pip install -r requirements.txt

--- a/launch.bat
+++ b/launch.bat
@@ -1,0 +1,3 @@
+@echo off
+venv\Scripts\python bot.py
+pause

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+discord.py>=2.0.0
+aiohttp>=3.8.0


### PR DESCRIPTION
## Summary
- implement Python Discord bot that posts all messages to a local HTTP endpoint and handles `!req`
- add config, batch installers/launchers, and instructions
- document progress and next steps in agents notes

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68b38ecb5df4832db4cbe550f020bdcf